### PR TITLE
Do not tamper with the root logger

### DIFF
--- a/src/unoserver/__init__.py
+++ b/src/unoserver/__init__.py
@@ -1,0 +1,4 @@
+import logging
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler())

--- a/src/unoserver/converter.py
+++ b/src/unoserver/converter.py
@@ -17,7 +17,6 @@ import unohelper
 from com.sun.star.beans import PropertyValue
 from com.sun.star.io import XOutputStream
 
-logging.basicConfig()
 logger = logging.getLogger("unoserver")
 logger.setLevel(logging.DEBUG)
 

--- a/src/unoserver/converter.py
+++ b/src/unoserver/converter.py
@@ -17,7 +17,7 @@ import unohelper
 from com.sun.star.beans import PropertyValue
 from com.sun.star.io import XOutputStream
 
-logger = logging.getLogger("unoserver")
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 SFX_FILTER_IMPORT = 1

--- a/src/unoserver/server.py
+++ b/src/unoserver/server.py
@@ -6,7 +6,6 @@ import subprocess
 import tempfile
 from urllib import request
 
-logging.basicConfig()
 logger = logging.getLogger("unoserver")
 logger.setLevel(logging.INFO)
 

--- a/src/unoserver/server.py
+++ b/src/unoserver/server.py
@@ -6,7 +6,7 @@ import subprocess
 import tempfile
 from urllib import request
 
-logger = logging.getLogger("unoserver")
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 


### PR DESCRIPTION
Calling `logger.basicConfig()` is not desirable in this place as it alters the root logger and overrides custom formatters of downstream users.