### PR TITLE
fix: windows incompatibilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+#ide
+.idea/

--- a/src/unoserver/converter.py
+++ b/src/unoserver/converter.py
@@ -137,7 +137,7 @@ class UnoConverter:
             # exceptions are completely useless!
 
             if not Path(inpath).exists():
-                raise RuntimeError(f"Opening path {inpath} not exists.")
+                raise RuntimeError(f"Path {inpath} does not exist.")
 
             # Load the document
             import_path = uno.systemPathToFileUrl(os.path.abspath(inpath))

--- a/src/unoserver/converter.py
+++ b/src/unoserver/converter.py
@@ -14,6 +14,7 @@ import os
 import sys
 import unohelper
 
+from pathlib import Path
 from com.sun.star.beans import PropertyValue
 from com.sun.star.io import XOutputStream
 
@@ -134,6 +135,9 @@ class UnoConverter:
         if inpath:
             # TODO: Verify that inpath exists and is openable, and that outdir exists, because uno's
             # exceptions are completely useless!
+
+            if not Path(inpath).exists():
+                raise RuntimeError(f"Opening path {inpath} not exists.")
 
             # Load the document
             import_path = uno.systemPathToFileUrl(os.path.abspath(inpath))

--- a/src/unoserver/server.py
+++ b/src/unoserver/server.py
@@ -25,7 +25,7 @@ class UnoServer:
                     % (self.interface, self.port)
             )
 
-            # Store this as an attribute, it helps testing                       
+            # Store this as an attribute, it helps testing
             # In windows if the path is invalid causes bootstrap.ini strange corrupt error
             self.tmp_uri = Path(tmpuserdir).as_uri()
 

--- a/src/unoserver/server.py
+++ b/src/unoserver/server.py
@@ -25,8 +25,8 @@ class UnoServer:
             )
 
             # Store this as an attribute, it helps testing                       
-            # In windows if the path is invalid causes bootstrap.ini strange corrupt error
-            self.tmp_uri = "file:" + ('//' if platform.system() == 'Linux' else '') + request.pathname2url(tmpuserdir)
+            # In windows if the tmp path is invalid causes bootstrap.ini strange corrupt error, see pathname2url implementation                  
+            self.tmp_uri = f"file:{request.pathname2url(tmpuserdir)}"
 
             # I think only --headless and --norestore are needed for
             # command line usage, but let's add everything to be safe.

--- a/src/unoserver/server.py
+++ b/src/unoserver/server.py
@@ -37,10 +37,10 @@ class UnoServer:
                 "--nodefault",
                 "--nologo",
                 "--nofirststartwizard",
-                "--norestore",                
+                "--norestore",
                 f"--accept={connection}",
             ]
-            
+
             # In Windows seems not work, display bootstrap.ini corrupt error?
             if platform.system() == 'Linux':
                 cmd.append(f"-env:UserInstallation={self.tmp_uri}")
@@ -57,7 +57,7 @@ class UnoServer:
                     if e.errno != 3:
                         raise
 
-            signal.signal(signal.SIGTERM, signal_handler)            
+            signal.signal(signal.SIGTERM, signal_handler)
             signal.signal(signal.SIGINT, signal_handler)
             
             # In Windows not exists a signal called SIGHUP

--- a/src/unoserver/server.py
+++ b/src/unoserver/server.py
@@ -25,8 +25,8 @@ class UnoServer:
             )
 
             # Store this as an attribute, it helps testing                       
-            # In windows if the tmp path is invalid causes bootstrap.ini strange corrupt error, see pathname2url implementation                  
-            self.tmp_uri = f"file:{request.pathname2url(tmpuserdir)}"
+            # In windows if the path is invalid causes bootstrap.ini strange corrupt error
+            self.tmp_uri = "file:" + ('//' if platform.system() == 'Linux' else '') + request.pathname2url(tmpuserdir)
 
             # I think only --headless and --norestore are needed for
             # command line usage, but let's add everything to be safe.

--- a/src/unoserver/server.py
+++ b/src/unoserver/server.py
@@ -24,8 +24,9 @@ class UnoServer:
                 % (self.interface, self.port)
             )
 
-            # Store this as an attribute, it helps testing
-            self.tmp_uri = "file://" + request.pathname2url(tmpuserdir)
+            # Store this as an attribute, it helps testing                       
+            # In windows if the path is invalid causes bootstrap.ini strange corrupt error
+            self.tmp_uri = "file:" + ('//' if platform.system() == 'Linux' else '') + request.pathname2url(tmpuserdir)
 
             # I think only --headless and --norestore are needed for
             # command line usage, but let's add everything to be safe.
@@ -38,12 +39,9 @@ class UnoServer:
                 "--nologo",
                 "--nofirststartwizard",
                 "--norestore",
+                f"-env:UserInstallation={self.tmp_uri}",
                 f"--accept={connection}",
-            ]
-
-            # In Windows seems not work, display bootstrap.ini corrupt error?
-            if platform.system() == 'Linux':
-                cmd.append(f"-env:UserInstallation={self.tmp_uri}")
+            ]            
 
             logger.info("Command: " + " ".join(cmd))
             process = subprocess.Popen(cmd)


### PR DESCRIPTION
Hi guys! Thanks for the project. 
Today i managed to work with unoserver in windows, and i have a fell breakpoints.

1) In server.py when executing in windows the command `f"-env:UserInstallation={self.tmp_uri}"` displays a strange error [see example](https://stackoverflow.com/questions/60413854/libreoffice-cannot-be-started-at-runtime-in-php), seems not necessary for `soffice.exe` that command. So, i added a Linux verification to append it.

2) In server.py when executing in windows, the process crashes because not exists a signal SIGHUP in Windows envrionment, so i added a verification as well.

By change that, works like a charm! Please consider the pull request for Windows users. Thanks again!

Edit 1: The issue with Windows is because the temporary uri generation gives an invalid path to process creation, causing the error, commit fixed.