### PR TITLE
fix(pre-commit-hooks): update black to 22.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
--   repo: https://github.com/psf/black
-    rev: 19.3b0
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
     hooks:
-    -   id: black
--   repo: https://github.com/pycqa/flake8
+      - id: black
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
-    -   id: flake8
--   repo: https://github.com/regebro/pyroma
-    rev: '3.2'
+      - id: flake8
+  - repo: https://github.com/regebro/pyroma
+    rev: "3.2"
     hooks:
-    -   id: pyroma
+      - id: pyroma


### PR DESCRIPTION
An incompatibility between "black" and its dependency "click" was fixed in black v22.3.0. Ref. https://stackoverflow.com/a/71674345