### PR TITLE
Add `--user-installation` flag to `unoserver`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ----------------
 
 - Added support for passing in filter options with the --filter-options parameter.
+- Add `--user-installation` flag to `unoserver`
 
 
 1.4 (2023-04-28)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -8,3 +8,4 @@ Contributors
 * Balázs Varga, https://github.com/bvarga91
 * Alessandro Filippini, https://github.com/AlePini
 * Dmitry Shachnev, https://github.com/mitya57
+* Socheat Sok, https://github.com/socheatsok78

--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,7 @@ Unoserver
 * `--port`: The port used by the server, defaults to "2002"
 * `--daemon`:  Deamonize the server
 * `--executable`: The path to the LibreOffice executable
+* `--user-installation`: The path to the LibreOffice user profile, defaults to a dynamically created temporary directory
 
 Unoconvert
 ~~~~~~~~~~

--- a/src/unoserver/server.py
+++ b/src/unoserver/server.py
@@ -27,51 +27,46 @@ class UnoServer:
     def start(self, executable="libreoffice"):
         logger.info("Starting unoserver.")
 
-        with tempfile.TemporaryDirectory() as tmpuserdir:
-            connection = (
-                "socket,host=%s,port=%s,tcpNoDelay=1;urp;StarOffice.ComponentContext"
-                % (self.interface, self.port)
-            )
+        connection = (
+            "socket,host=%s,port=%s,tcpNoDelay=1;urp;StarOffice.ComponentContext"
+            % (self.interface, self.port)
+        )
 
-            # Store this as an attribute, it helps testing
-            # In windows if the path is invalid causes bootstrap.ini strange corrupt error
-            self.tmp_uri = Path(tmpuserdir).as_uri()
+        # I think only --headless and --norestore are needed for
+        # command line usage, but let's add everything to be safe.
+        cmd = [
+            executable,
+            "--headless",
+            "--invisible",
+            "--nocrashreport",
+            "--nodefault",
+            "--nologo",
+            "--nofirststartwizard",
+            "--norestore",
+            f"-env:UserInstallation={self.user_installation}",
+            f"--accept={connection}",
+        ]
 
-            # I think only --headless and --norestore are needed for
-            # command line usage, but let's add everything to be safe.
-            cmd = [
-                executable,
-                "--headless",
-                "--invisible",
-                "--nocrashreport",
-                "--nodefault",
-                "--nologo",
-                "--nofirststartwizard",
-                "--norestore",
-                f"-env:UserInstallation={self.tmp_uri}",
-                f"--accept={connection}",
-            ]
+        logger.info("Command: " + " ".join(cmd))
+        process = subprocess.Popen(cmd)
 
-            logger.info("Command: " + " ".join(cmd))
-            process = subprocess.Popen(cmd)
+        def signal_handler(signum, frame):
+            logger.info("Sending signal to LibreOffice")
+            try:
+                process.send_signal(signum)
+            except ProcessLookupError as e:
+                # 3 means the process is already dead
+                if e.errno != 3:
+                    raise
 
-            def signal_handler(signum, frame):
-                logger.info("Sending signal to LibreOffice")
-                try:
-                    process.send_signal(signum)
-                except ProcessLookupError as e:
-                    # 3 means the process is already dead
-                    if e.errno != 3:
-                        raise
+        signal.signal(signal.SIGTERM, signal_handler)
+        signal.signal(signal.SIGINT, signal_handler)
 
-            signal.signal(signal.SIGTERM, signal_handler)
-            signal.signal(signal.SIGINT, signal_handler)
+        # Signal SIGHUP is available only in Unix systems
+        if platform.system() != "Windows":
+            signal.signal(signal.SIGHUP, signal_handler)
 
-            # Signal SIGHUP is available only in Unix systems
-            if platform.system() != "Windows":
-                signal.signal(signal.SIGHUP, signal_handler)
-
-            return process
+        return process
 
 
 def main():

--- a/src/unoserver/server.py
+++ b/src/unoserver/server.py
@@ -11,10 +11,10 @@ logger = logging.getLogger("unoserver")
 
 
 class UnoServer:
-    def __init__(self, interface="127.0.0.1", port="2002"):
+    def __init__(self, interface="127.0.0.1", port="2002", user_installation=None):
         self.interface = interface
         self.port = port
-        self.user_installation = None
+        self.user_installation = user_installation
 
     def start(self, executable="libreoffice"):
         logger.info("Starting unoserver.")

--- a/src/unoserver/server.py
+++ b/src/unoserver/server.py
@@ -84,9 +84,9 @@ def main():
     args = parser.parse_args()
 
     with tempfile.TemporaryDirectory() as tmpuserdir:
-        if args.user_installation is None:
-            user_installation = Path(tmpuserdir).as_uri()
-        else:
+        user_installation = Path(tmpuserdir).as_uri()
+        
+        if args.user_installation is not None:
             user_installation = Path(args.user_installation).as_uri()
 
         server = UnoServer(

--- a/src/unoserver/server.py
+++ b/src/unoserver/server.py
@@ -11,18 +11,10 @@ logger = logging.getLogger("unoserver")
 
 
 class UnoServer:
-    def __init__(self, interface="127.0.0.1", port="2002", user_installation=None):
+    def __init__(self, interface="127.0.0.1", port="2002"):
         self.interface = interface
         self.port = port
-
-        if user_installation is None:
-            with tempfile.TemporaryDirectory() as tmpuserdir:
-                # Store this as an attribute, it helps testing
-                # In windows if the path is invalid causes bootstrap.ini strange corrupt error
-                self.tmp_uri = Path(tmpuserdir).as_uri()
-                self.user_installation = self.tmp_uri
-        else:
-            self.user_installation = Path(user_installation).as_uri()
+        self.user_installation = None
 
     def start(self, executable="libreoffice"):
         logger.info("Starting unoserver.")
@@ -94,8 +86,16 @@ def main():
     server = UnoServer(
         args.interface,
         args.port,
-        args.user_installation,
     )
+
+    if args.user_installation is None:
+        with tempfile.TemporaryDirectory() as tmpuserdir:
+            # Store this as an attribute, it helps testing
+            # In windows if the path is invalid causes bootstrap.ini strange corrupt error
+            server.tmp_uri = Path(tmpuserdir).as_uri()
+            server.user_installation = server.tmp_uri
+    else:
+        server.user_installation = Path(args.user_installation).as_uri()
 
     # If it's daemonized, this returns the process.
     # It returns 0 of getting killed in a normal way.

--- a/src/unoserver/server.py
+++ b/src/unoserver/server.py
@@ -19,8 +19,8 @@ class UnoServer:
             with tempfile.TemporaryDirectory() as tmpuserdir:
                 # Store this as an attribute, it helps testing
                 # In windows if the path is invalid causes bootstrap.ini strange corrupt error
-                tmp_uri = Path(tmpuserdir).as_uri()
-                self.user_installation = tmp_uri
+                self.tmp_uri = Path(tmpuserdir).as_uri()
+                self.user_installation = self.tmp_uri
         else:
             self.user_installation = Path(user_installation).as_uri()
 

--- a/src/unoserver/server.py
+++ b/src/unoserver/server.py
@@ -22,7 +22,7 @@ class UnoServer:
                 tmp_uri = Path(tmpuserdir).as_uri()
                 self.user_installation = tmp_uri
         else:
-            self.user_installation = user_installation
+            self.user_installation = Path(user_installation).as_uri()
 
     def start(self, executable="libreoffice"):
         logger.info("Starting unoserver.")

--- a/src/unoserver/server.py
+++ b/src/unoserver/server.py
@@ -79,21 +79,17 @@ def main():
     parser.add_argument(
         "--user-installation",
         default=None,
-        help="The path to the LibreOffice user profile"
+        help="The path to the LibreOffice user profile",
     )
     args = parser.parse_args()
 
     with tempfile.TemporaryDirectory() as tmpuserdir:
         user_installation = Path(tmpuserdir).as_uri()
-        
+
         if args.user_installation is not None:
             user_installation = Path(args.user_installation).as_uri()
 
-        server = UnoServer(
-            args.interface,
-            args.port,
-            user_installation
-        )
+        server = UnoServer(args.interface, args.port, user_installation)
 
         # If it's daemonized, this returns the process.
         # It returns 0 of getting killed in a normal way.

--- a/src/unoserver/server.py
+++ b/src/unoserver/server.py
@@ -11,9 +11,18 @@ logger = logging.getLogger("unoserver")
 
 
 class UnoServer:
-    def __init__(self, interface="127.0.0.1", port="2002"):
+    def __init__(self, interface="127.0.0.1", port="2002", user_installation=None):
         self.interface = interface
         self.port = port
+
+        if user_installation is None:
+            with tempfile.TemporaryDirectory() as tmpuserdir:
+                # Store this as an attribute, it helps testing
+                # In windows if the path is invalid causes bootstrap.ini strange corrupt error
+                tmp_uri = Path(tmpuserdir).as_uri()
+                self.user_installation = tmp_uri
+        else:
+            self.user_installation = user_installation
 
     def start(self, executable="libreoffice"):
         logger.info("Starting unoserver.")
@@ -80,9 +89,19 @@ def main():
         default="libreoffice",
         help="The path to the LibreOffice executable",
     )
+    parser.add_argument(
+        "--user-installation",
+        default=None,
+        help="The path to the LibreOffice user profile"
+    )
     args = parser.parse_args()
 
-    server = UnoServer(args.interface, args.port)
+    server = UnoServer(
+        args.interface,
+        args.port,
+        args.user_installation,
+    )
+
     # If it's daemonized, this returns the process.
     # It returns 0 of getting killed in a normal way.
     # Otherwise it returns 1 after the process exits.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,18 @@
 import pytest
 import time
+import tempfile
+from pathlib import Path
 
 from unoserver import server
 
-
 @pytest.fixture(scope="session")
 def server_fixture():
-    srvr = server.UnoServer()
-    process = srvr.start()
-    # Give libreoffice a chance to start
-    time.sleep(8)
-    yield process  # provide the fixture value
-    print("Teardown Unoserver")
-    process.terminate()
+    with tempfile.TemporaryDirectory() as tmpuserdir:
+        user_installation = Path(tmpuserdir).as_uri()
+        srvr = server.UnoServer(user_installation=user_installation)
+        process = srvr.start()
+        # Give libreoffice a chance to start
+        time.sleep(8)
+        yield process  # provide the fixture value
+        print("Teardown Unoserver")
+        process.terminate()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from unoserver import server
 
+
 @pytest.fixture(scope="session")
 def server_fixture():
     with tempfile.TemporaryDirectory() as tmpuserdir:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -21,7 +21,7 @@ def test_server_params(popen_mock):
             "--nologo",
             "--nofirststartwizard",
             "--norestore",
-            f"-env:UserInstallation={srv.tmp_uri}",
+            f"-env:UserInstallation={srv.user_installation}",
             "--accept=socket,host=127.0.0.1,port=2002,tcpNoDelay=1;urp;StarOffice.ComponentContext",
         ]
     )


### PR DESCRIPTION
I found myself needing to have a persistence `UserInstallation`. This should add the ability to set custom `--user-installation` and still keep the old functionality the same.