### PR TITLE
Add IPV6 support to unoserver

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -26,3 +26,23 @@ def test_server_params(popen_mock, thread_mock):
             "--accept=socket,host=127.0.0.1,port=2202,tcpNoDelay=1;urp;StarOffice.ComponentContext",
         ]
     )
+
+@mock.patch("threading.Thread")
+@mock.patch("subprocess.Popen")
+def test_server_ipv6_params(popen_mock, thread_mock):
+    srv = server.UnoServer(interface="::", port="2203", uno_port="2202")
+    srv.start()
+    popen_mock.assert_called_with(
+        [
+            "libreoffice",
+            "--headless",
+            "--invisible",
+            "--nocrashreport",
+            "--nodefault",
+            "--nologo",
+            "--nofirststartwizard",
+            "--norestore",
+            f"-env:UserInstallation={srv.user_installation}",
+            "--accept=socket,host=127.0.0.1,port=2202,tcpNoDelay=1;urp;StarOffice.ComponentContext",
+        ]
+    )


### PR DESCRIPTION
Add support to unoserver by resolving the address information of the network interface before socket initialization. I also added a unit test that passes a ipv6 interface to the `Unoserver` class.

#104 