### PR TITLE
Use sudo -H instead of sudo on Readme to avoid ruin the permissions of the pip cache folder

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,13 +34,13 @@ NB! Windows and Mac support is as of yet untested.
 Unoserver needs to be installed by and run with the same Python installation that LibreOffice uses.
 On Unix this usually means you can just install it with::
 
-   $ sudo pip install unoserver
+   $ sudo -H pip install unoserver
 
 If you have multiple versions of LibreOffice installed, you need to install it for each one.
 Usually each LibreOffice install will have it's own `python` executable and you need to run
 `pip` with that executable::
 
-  $ sudo /full/path/to/python -m pip install unoserver
+  $ sudo -H /full/path/to/python -m pip install unoserver
 
 To find all Python installations that have the relevant LibreOffice libraries installed,
 you can run a script called `find_uno.py`::


### PR DESCRIPTION
## Motivation and Context


Assuming that I am a regular Linux user named `luzfcb`, with the HOME folder located in `/home/luzfcb` and the `$HOME `environment variable pointing to `/home/luzfcb`


`sudo` **without** `-H` modifier will run the command with `root` permissions, but using the `$HOME` environment variable of the current user ( not the `root` )
`pip` will use the `$HOME` environment variable to create a cache directory on `/home/luzfcb/.cache/pip/`, but all new files/directories will be created with `root` permission, and root-only read permission; that is, the `luzfcb` user has no `write` or `read` permission to some of the directories inside `/home/luzfcb/.cache/pip/` .


`sudo` **with** the `-H` modifier will run the command with `root` permissions and use the `root` user's `$HOME `environment variable instead of the current user's `$HOME`.


So, if we use `sudo` **with** the `-H` modifier to run `pip`, the `pip` will use the `$HOME` environment variable of the root user to create a cache directory on `/root/.cache/pip/`, and all future sufferings will be avoided :-) .

Another option, to not use `sudo` with `-H`, is use `pip` with `--no-cache-dir`


## <a name="description" href="#description">Description</a>

This pull-request adds the `-H` modifier the `sudo ` when it is used the `pip` on the Readme
