### PR TITLE
Add `--stop-after` parameter to `unoserver`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,8 @@ Unoserver
 
   unoserver [-h] [-v] [--interface INTERFACE] [--uno-interface UNO_INTERFACE] [--port PORT] [--uno-port UNO_PORT]
             [--daemon] [--executable EXECUTABLE] [--user-installation USER_INSTALLATION]
-            [--libreoffice-pid-file LIBREOFFICE_PID_FILE]
+            [--libreoffice-pid-file LIBREOFFICE_PID_FILE] [--conversion-timeout CONVERSION_TIMEOUT]
+            [--stop-after STOP_AFTER]
 
 * `--interface`: The interface used by the XMLRPC server, defaults to "127.0.0.1"
 * `--port`: The port used by the XMLRPC server, defaults to "2003"
@@ -110,6 +111,7 @@ Unoserver
 * `--libreoffice-pid-file`: If set, unoserver will write the Libreoffice PID to this file.
   If started in daemon mode, the file will not be deleted when unoserver exits.
 * `--conversion-timeout`: Terminate Libreoffice and exit if a conversion does not complete in the given time (in seconds).
+* `--stop-after`: Terminate Libreoffice and exit after the given number of requests.
 * `-v, --version`: Display version and exit.
 
 Unoconvert

--- a/src/unoserver/server.py
+++ b/src/unoserver/server.py
@@ -66,10 +66,6 @@ class UnoServer:
         self.xmlrcp_server = None
         self.intentional_exit = False
 
-        if self.stop_after is not None:
-            self.thread_lock = threading.Lock()
-            self.number_of_requests = 0
-
     def start(self, executable="libreoffice"):
         logger.info(f"Starting unoserver {__version__}.")
 
@@ -144,18 +140,19 @@ class UnoServer:
             self.xmlrcp_server = server
             server.register_introspection_functions()
 
+            self.number_of_requests = 0
+
             def stop_after():
                 if self.stop_after is None:
                     return
-                with self.thread_lock:
-                    self.number_of_requests += 1
-                    if self.number_of_requests == self.stop_after:
-                        logger.info(
-                            "Processed %d requests, exiting.",
-                            self.stop_after,
-                        )
-                        self.intentional_exit = True
-                        self.libreoffice_process.terminate()
+                self.number_of_requests += 1
+                if self.number_of_requests == self.stop_after:
+                    logger.info(
+                        "Processed %d requests, exiting.",
+                        self.stop_after,
+                    )
+                    self.intentional_exit = True
+                    self.libreoffice_process.terminate()
 
             @server.register_function
             def info():


### PR DESCRIPTION
When using `unoserver` as a long-running service, it is often useful to restart both `unoserver` and LibreOffice after a certain number of requests (e.g. 1,000), so that any potential bad state is reset and any potential misallocated memory in LibreOffice is freed.

This PR adds the parameter `--stop-after` to `unoserver`:
* `--stop-after`: Terminate Libreoffice and exit after the given number of requests.

### Demonstation

Here is a demonstration of using the new parameter.

First, we spin up a Docker container with Ubuntu, LibreOffice, Python, and the code from this PR:

```
$ docker run --name unoserver-stop-after --rm -it ubuntu
# apt update
# apt install git libreoffice python3 python3-pip wget
# pip install -U pip wheel setuptools
# pip install git+https://github.com/witiko/unoserver@feat/stop-after
```

Next, we download [an example DOCX file][1] and we launch `unoserver` with the parameter `--stop-after 5`:

```
# wget https://calibre-ebook.com/downloads/demos/demo.docx
# unoserver --stop-after 5
```
```
INFO:unoserver:Starting unoserver 3.0.2.dev0.
INFO:unoserver:Command: /usr/bin/soffice --headless --invisible --nocrashreport --nodefault --nologo --nofirststartwizard --norestore -env:UserInstallation=file:///tmp/tmpm2fgj8md --accept=socket,host=127.0.0.1,port=2002,tcpNoDelay=1;urp;StarOffice.ComponentContext
INFO:unoserver:Starting UnoConverter.
INFO:unoserver:Starting UnoComparer.
INFO:unoserver:Server PID: 11762
```

Finally, from the outside of the container, we launch 5 conversions:

```
$ for _ in {1..5}; do docker exec unoserver-stop-after unoconvert /demo.docx /demo.odt; done
```
```
INFO:unoserver:Connecting.
INFO:unoserver:Converting.
INFO:unoserver:Saved to /demo.odt.
INFO:unoserver:Connecting.
INFO:unoserver:Converting.
INFO:unoserver:Saved to /demo.odt.
INFO:unoserver:Connecting.
INFO:unoserver:Converting.
INFO:unoserver:Saved to /demo.odt.
INFO:unoserver:Connecting.
INFO:unoserver:Converting.
INFO:unoserver:Saved to /demo.odt.
INFO:unoserver:Connecting.
INFO:unoserver:Converting.
INFO:unoserver:Saved to /demo.odt.
```

Meanwhile, in the container, we can see that `unoserver` has exited with a zero exit code after the fifth conversion:

```
127.0.0.1 - - [30/Oct/2024 13:04:56] "POST /RPC2 HTTP/1.1" 200 -
INFO:unoserver:Opening /demo.docx for input
INFO:unoserver:Exporting to /demo.odt
INFO:unoserver:Using writer8 export filter from None to writer8
127.0.0.1 - - [30/Oct/2024 13:04:57] "POST /RPC2 HTTP/1.1" 200 -
127.0.0.1 - - [30/Oct/2024 13:05:16] "POST /RPC2 HTTP/1.1" 200 -
INFO:unoserver:Opening /demo.docx for input
INFO:unoserver:Exporting to /demo.odt
INFO:unoserver:Using writer8 export filter from None to writer8
127.0.0.1 - - [30/Oct/2024 13:05:17] "POST /RPC2 HTTP/1.1" 200 -
127.0.0.1 - - [30/Oct/2024 13:05:17] "POST /RPC2 HTTP/1.1" 200 -
INFO:unoserver:Opening /demo.docx for input
INFO:unoserver:Exporting to /demo.odt
INFO:unoserver:Using writer8 export filter from None to writer8
127.0.0.1 - - [30/Oct/2024 13:05:17] "POST /RPC2 HTTP/1.1" 200 -
127.0.0.1 - - [30/Oct/2024 13:05:17] "POST /RPC2 HTTP/1.1" 200 -
INFO:unoserver:Opening /demo.docx for input
INFO:unoserver:Exporting to /demo.odt
INFO:unoserver:Using writer8 export filter from None to writer8
127.0.0.1 - - [30/Oct/2024 13:05:18] "POST /RPC2 HTTP/1.1" 200 -
127.0.0.1 - - [30/Oct/2024 13:05:18] "POST /RPC2 HTTP/1.1" 200 -
INFO:unoserver:Opening /demo.docx for input
INFO:unoserver:Exporting to /demo.odt
INFO:unoserver:Using writer8 export filter from None to writer8
INFO:unoserver:Processed 5 requests, exiting.
127.0.0.1 - - [30/Oct/2024 13:05:19] "POST /RPC2 HTTP/1.1" 200 -
```
```
# echo $?
```
```
0
```

 [1]: https://calibre-ebook.com/downloads/demos/demo.docx