### PR TITLE
Enhance filter option handling for HTML image embedding support

### DIFF
--- a/src/unoserver/converter.py
+++ b/src/unoserver/converter.py
@@ -300,8 +300,17 @@ class UnoConverter:
             )
 
             filter_data = []
+            output_props = (
+                PropertyValue(Name="FilterName", Value=filtername),
+                PropertyValue(Name="Overwrite", Value=True),
+            )
             for option in filter_options:
                 option_name, option_value = option.split("=", maxsplit=1)
+                if option_name == "EmbedImages" and option_value != "false":
+                    output_props += (
+                        PropertyValue(Name="FilterOptions", Value="EmbedImages"),
+                    )
+                    continue
                 if option_value == "false":
                     option_value = False
                 elif option_value == "true":
@@ -309,10 +318,6 @@ class UnoConverter:
                 elif option_value.isdecimal():
                     option_value = int(option_value)
                 filter_data.append(PropertyValue(Name=option_name, Value=option_value))
-            output_props = (
-                PropertyValue(Name="FilterName", Value=filtername),
-                PropertyValue(Name="Overwrite", Value=True),
-            )
             if outpath is None:
                 output_stream = OutputStream()
                 output_props += (


### PR DESCRIPTION
The default behaviour of embedding images as base64 strings in output HTML files was changed for newer libreoffice versions. This was then made optional and you could specify this in the soffice commands like so:

`soffice –headless --convert-to html:HTML:EmbedImages test_file.docx`

However using `--filter-options EmbedImages=true` does not work, because it sets `FilterData` property, whereas for `EmbedImages` option `FilterOptions` property needs to be set to `EmbedImages`.

This PR makes it possible to use `EmbedImages` filter option this way:
`unoconvert --convert-to html --filter HTML --filter-options EmbedImages=true test_file.docx test_file.html`
or just
`unoconvert --convert-to html --filter HTML --filter-options EmbedImages= test_file.docx test_file.html`

Fixes #24 #75 #110 