### PR TITLE
feat: add --temp-dir option to customize temporary file directory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ Unoserver
   unoserver [-h] [-v] [--interface INTERFACE] [--uno-interface UNO_INTERFACE] [--port PORT] [--uno-port UNO_PORT]
             [--daemon] [--executable EXECUTABLE] [--user-installation USER_INSTALLATION]
             [-p/--libreoffice-pid-file LIBREOFFICE_PID_FILE] [--conversion-timeout CONVERSION_TIMEOUT]
-            [--stop-after STOP_AFTER] [--verbose] [--quiet] [-f/--logfile logfile]
+            [--stop-after STOP_AFTER] [--temp-dir TEMP_DIR] [--verbose] [--quiet] [-f/--logfile logfile]
 
 * `-v, --version`: Display version and exit.
 * `--interface`: The interface used by the XMLRPC server, defaults to "127.0.0.1"
@@ -114,6 +114,7 @@ Unoserver
   If started in daemon mode, the file will not be deleted when unoserver exits.
 * `--conversion-timeout`: Terminate Libreoffice and exit if a conversion does not complete in the given time (in seconds).
 * `--stop-after`: Terminate Libreoffice and exit after the given number of requests.
+* `--temp-dir`: The directory to use for temporary files. Useful for avoiding permission issues with system temp directories (e.g., C:\Windows\Temp on Windows). If not specified, uses system default temp directory.
 * `--verbose`: Add debug information as output
 * `--quiet`: Only output errors and warnings
 * `-f`, `--logfile`: Write logs to a file (defaults to stderr)

--- a/src/unoserver/converter.py
+++ b/src/unoserver/converter.py
@@ -51,7 +51,7 @@ def get_doc_type(doc):
 
 
 @contextlib.contextmanager
-def TempFileIfNeeded(path, suffix=None, data=None):
+def TempFileIfNeeded(path, suffix=None, data=None, temp_dir=None):
     """Takes an path and data
 
     If path is None or empty, then it creates a temporary file,
@@ -64,16 +64,29 @@ def TempFileIfNeeded(path, suffix=None, data=None):
     if path:
         yield path
     else:
+        # Normalize suffix to include leading dot if present
         if suffix:
-            suffix = "." + suffix
+            suffix = "." + suffix.lstrip(".")
         else:
             suffix = ""
-        with tempfile.NamedTemporaryFile(suffix=suffix) as file:
+        # Ensure temp directory exists and is accessible
+        if temp_dir:
+            os.makedirs(temp_dir, exist_ok=True)
+        with tempfile.NamedTemporaryFile(suffix=suffix, dir=temp_dir, delete=False) as file:
             if data:
                 file.file.write(data)
-            file.file.close()
-
-            yield file.name
+            file.file.flush()  # Ensure data is written to disk
+            temp_path = file.name
+        
+        try:
+            yield temp_path
+        finally:
+            # Clean up the temporary file after conversion
+            try:
+                if os.path.exists(temp_path):
+                    os.unlink(temp_path)
+            except Exception as e:
+                logger.warning(f"Failed to clean up temporary file {temp_path}: {e}")
 
 
 class UnoConverter:
@@ -82,7 +95,7 @@ class UnoConverter:
     Don't use this directly, instead use the client.UnoConverter.
     """
 
-    def __init__(self, interface="127.0.0.1", port="2002"):
+    def __init__(self, interface="127.0.0.1", port="2002", temp_dir=None):
         self.local_context = uno.getComponentContext()
         self.resolver = self.local_context.ServiceManager.createInstanceWithContext(
             "com.sun.star.bridge.UnoUrlResolver", self.local_context
@@ -100,6 +113,7 @@ class UnoConverter:
         self.type_service = self.service.createInstanceWithContext(
             "com.sun.star.document.TypeDetection", self.context
         )
+        self.temp_dir = temp_dir
         self._export_filters = None
         self._import_filters = None
 
@@ -217,7 +231,7 @@ class UnoConverter:
                     f"There is no '{infiltername}' import filter. Available filters: {sorted(infilters.keys())}"
                 )
 
-        with TempFileIfNeeded(inpath, data=indata) as input_path:
+        with TempFileIfNeeded(inpath, data=indata, temp_dir=self.temp_dir) as input_path:
             # TODO: Verify that inpath exists and is openable, and that outdir exists, because uno's
             # exceptions are completely useless!
             if not Path(input_path).exists():
@@ -266,7 +280,7 @@ class UnoConverter:
                 # Figure out document type:
                 import_type = get_doc_type(document)
 
-                with TempFileIfNeeded(outpath, convert_to) as output_path:
+                with TempFileIfNeeded(outpath, convert_to, temp_dir=self.temp_dir) as output_path:
 
                     # Make a URL
                     export_url = uno.systemPathToFileUrl(os.path.abspath(output_path))

--- a/src/unoserver/server.py
+++ b/src/unoserver/server.py
@@ -54,6 +54,7 @@ class UnoServer:
         user_installation=None,
         conversion_timeout=None,
         stop_after=None,
+        temp_dir=None,
     ):
         self.interface = interface
         self.uno_interface = uno_interface
@@ -62,6 +63,7 @@ class UnoServer:
         self.user_installation = user_installation
         self.conversion_timeout = conversion_timeout
         self.stop_after = stop_after
+        self.temp_dir = temp_dir
         self.libreoffice_process = None
         self.xmlrcp_thread = None
         self.xmlrcp_server = None
@@ -136,7 +138,7 @@ class UnoServer:
             while attempts > 0:
                 try:
                     self.conv = converter.UnoConverter(
-                        interface=self.uno_interface, port=self.uno_port
+                        interface=self.uno_interface, port=self.uno_port, temp_dir=self.temp_dir
                     )
                     break
                 except UnoException as e:
@@ -598,6 +600,11 @@ def main():
         type=int,
         help="Terminate Libreoffice and exit after the given number of requests.",
     )
+    parser.add_argument(
+        "--temp-dir",
+        default=None,
+        help="The directory to use for temporary files. If not specified, uses system default.",
+    )
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "--verbose",
@@ -654,7 +661,7 @@ def main():
         else:
             return proc.wait()
 
-    with tempfile.TemporaryDirectory() as tmpuserdir:
+    with tempfile.TemporaryDirectory(dir=args.temp_dir) as tmpuserdir:
         user_installation = Path(tmpuserdir).as_uri()
 
         if args.user_installation is not None:
@@ -671,6 +678,7 @@ def main():
             user_installation,
             args.conversion_timeout,
             args.stop_after,
+            args.temp_dir,
         )
 
         if args.executable is not None:


### PR DESCRIPTION
- Add temp_dir parameter to UnoConverter and UnoServer classes
- Update TempFileIfNeeded to support custom temp directory with proper cleanup
- Add --temp-dir CLI argument for specifying temporary file location
- Improve temporary file handling with explicit deletion and error handling
- Update README documentation for the new option

This change allows users to specify a custom directory for temporary files, which helps avoid permission issues on systems like Windows where the default temp directory (C:\Windows\Temp) may have restricted access.

Fixs #204 